### PR TITLE
Fix/seed and batch fixes

### DIFF
--- a/rrnco/envs/atsp/generator_lazy.py
+++ b/rrnco/envs/atsp/generator_lazy.py
@@ -248,12 +248,15 @@ class LazyATSPGenerator(Generator):
         locs = (points - points_min) / (points_max - points_min + 1e-6)
         locs = torch.from_numpy(locs)
 
+        # Use actual batch size from the data
+        actual_batch_size = [distance.shape[0]]
+
         return TensorDict(
             {
                 "locs": locs,
                 "distance_matrix": distance,
             },
-            batch_size=batch_size,
+            batch_size=actual_batch_size,
         )
 
     def _merge_tensordicts(self, tds: list) -> TensorDict:

--- a/rrnco/envs/rcvrp/generator_lazy.py
+++ b/rrnco/envs/rcvrp/generator_lazy.py
@@ -280,11 +280,14 @@ class LazyRCVRPGenerator(Generator):
         depot = torch.from_numpy(points[:, :1, :]).float()  # First point is depot
         locs = torch.from_numpy(points[:, 1:, :]).float()  # Rest are customer locations
 
+        # Use actual batch size from the data
+        actual_batch_size = [points.shape[0]]
+
         # Generate demand
-        demand = self.demand_sampler.sample((*batch_size, self.num_loc))
+        demand = self.demand_sampler.sample((*actual_batch_size, self.num_loc))
 
         # Generate capacity
-        capacity = torch.full((*batch_size, 1), self.capacity, dtype=torch.float32)
+        capacity = torch.full((*actual_batch_size, 1), self.capacity, dtype=torch.float32)
 
         # Add distance matrix if available
         td_data = {
@@ -298,7 +301,7 @@ class LazyRCVRPGenerator(Generator):
             distance = torch.from_numpy(chunk_data["distance_matrix"].astype(np.float32))
             td_data["distance_matrix"] = distance
 
-        return TensorDict(td_data, batch_size=batch_size)
+        return TensorDict(td_data, batch_size=actual_batch_size)
 
     def _merge_tensordicts(self, tds: list) -> TensorDict:
         """Efficiently merge multiple TensorDicts"""

--- a/rrnco/envs/rmtvrp/generator_lazy.py
+++ b/rrnco/envs/rmtvrp/generator_lazy.py
@@ -353,6 +353,9 @@ class LazyRMTVRPGenerator(Generator):
         distance = torch.from_numpy(chunk_data["distance_matrix"].astype(np.float32))
         duration = chunk_data["duration_matrix"].astype(np.float32)
 
+        # Use actual batch size from the data
+        actual_batch_size = [points.shape[0]]
+
         # Normalize locations
         points_min = np.min(points, axis=1, keepdims=True)
         points_max = np.max(points, axis=1, keepdims=True)
@@ -368,25 +371,25 @@ class LazyRMTVRPGenerator(Generator):
 
         # Generate all MTVRP components
         vehicle_capacity = torch.full(
-            (*batch_size, 1), self.capacity, dtype=torch.float32
+            (*actual_batch_size, 1), self.capacity, dtype=torch.float32
         )
         capacity_original = vehicle_capacity.clone()
 
         # Generate demands
         demand_linehaul, demand_backhaul = self.generate_demands(
-            batch_size=batch_size, num_loc=self.num_loc
+            batch_size=actual_batch_size, num_loc=self.num_loc
         )
 
         # Generate other components
         backhaul_class = self.generate_backhaul_class(
-            shape=(*batch_size, 1), sample=self.sample_backhaul_class
+            shape=(*actual_batch_size, 1), sample=self.sample_backhaul_class
         )
-        speed = self.generate_speed(shape=(*batch_size, 1))
+        speed = self.generate_speed(shape=(*actual_batch_size, 1))
         time_windows, service_time = self.generate_time_windows_with_duration_matrix(
             duration=normalized_duration
         )
-        open_route = self.generate_open_route(shape=(*batch_size, 1))
-        distance_limit = self.generate_distance_limit(shape=(*batch_size, 1), locs=locs)
+        open_route = self.generate_open_route(shape=(*actual_batch_size, 1))
+        distance_limit = self.generate_distance_limit(shape=(*actual_batch_size, 1), locs=locs)
 
         # Scale demands if needed
         if self.scale_demand:
@@ -410,7 +413,7 @@ class LazyRMTVRPGenerator(Generator):
                 "distance_matrix": distance,
                 "duration_matrix": normalized_duration,
             },
-            batch_size=batch_size,
+            batch_size=actual_batch_size,
         )
 
         return td

--- a/test.py
+++ b/test.py
@@ -4,6 +4,8 @@ import time
 import warnings
 
 import torch
+import numpy as np
+import random
 
 from rl4co.data.dataset import TensorDictDataset
 from rl4co.data.utils import load_npz_to_tensordict
@@ -33,6 +35,22 @@ try:
 except AttributeError:
     pass
 torch.set_float32_matmul_precision("medium")
+
+
+def set_seed(seed=1234):
+    """Set random seeds for reproducibility"""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)  # for multi-GPU
+
+    # Make CUDA operations deterministic
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+    # For PyTorch >= 1.12, ensure deterministic algorithms
+    torch.use_deterministic_algorithms(True, warn_only=True)
 
 
 def get_dataloader(td, batch_size=4):
@@ -69,11 +87,15 @@ if __name__ == "__main__":
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--no_aug", action="store_true", help="Disable data augmentation")
     parser.add_argument("--problem_size", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=1234, help="Random seed for reproducibility")
     # Use load_from_checkpoint with map_location, which is handled internally by Lightning
     # Suppress FutureWarnings related to torch.load and weights_only
     warnings.filterwarnings("ignore", message=".*weights_only.*", category=FutureWarning)
 
     opts = parser.parse_args()
+
+    # Set seed for reproducibility
+    set_seed(opts.seed)
     generator_params = {"num_loc": opts.problem_size}
     batch_size = opts.batch_size
     decode_type = opts.decode_type


### PR DESCRIPTION
## Changes
  - Add seed configuration for reproducible testing
  - Fix batch size mismatch in lazy generators (ATSP/RCVRP/RMTVRP)

  ## Details
  - test.py: Add set_seed() function with deterministic CUDA settings
  - generator_lazy.py: Use actual data batch size instead of requested size

  ## Testing
  - Verified training works with small batch sizes (128 samples)
  - No conflicts with recent ai4co/main changes